### PR TITLE
Add bounded file traversal and consolidate manifest cleanup

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -101,48 +101,45 @@ bool renameFile(const char *pathFrom, const char *pathTo)
 
 #include <vector>
 
-/**
- * @brief Get the list of files in a directory.
- *
- * This function returns a list of files in a directory. The list includes the full path of each file.
- * We can't use SPILOCK here because of recursion. Callers of this function should use SPILOCK.
- *
- * @param dirname The name of the directory.
- * @param levels The number of levels of subdirectories to list.
- * @return A vector of strings containing the full path of each file in the directory.
- */
-std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount)
-{
-    std::vector<meshtastic_FileInfo> filenames = {};
 #ifdef FSCom
+namespace
+{
+void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vector<meshtastic_FileInfo> &filenames,
+                  bool *wasLimited)
+{
     File root = FSCom.open(dirname, FILE_O_READ);
     if (!root)
-        return filenames;
-    if (!root.isDirectory())
-        return filenames;
+        return;
+    if (!root.isDirectory()) {
+        root.close();
+        return;
+    }
 
     File file = root.openNextFile();
     while (file) {
         if (filenames.size() >= maxCount) {
+            if (wasLimited)
+                *wasLimited = true;
             file.close();
             break;
         }
         if (file.isDirectory() && !String(file.name()).endsWith(".")) {
             if (levels) {
 #ifdef ARCH_ESP32
-                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.path(), levels - 1, maxCount - filenames.size());
+                collectFiles(file.path(), levels - 1, maxCount, filenames, wasLimited);
 #else
-                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.name(), levels - 1, maxCount - filenames.size());
+                collectFiles(file.name(), levels - 1, maxCount, filenames, wasLimited);
 #endif
-                filenames.insert(filenames.end(), subDirFilenames.begin(), subDirFilenames.end());
-                file.close();
+            } else if (wasLimited) {
+                *wasLimited = true;
             }
+            file.close();
         } else {
             meshtastic_FileInfo fileInfo = {"", static_cast<uint32_t>(file.size())};
 #ifdef ARCH_ESP32
-            strcpy(fileInfo.file_name, file.path());
+            strlcpy(fileInfo.file_name, file.path(), sizeof(fileInfo.file_name));
 #else
-            strcpy(fileInfo.file_name, file.name());
+            strlcpy(fileInfo.file_name, file.name(), sizeof(fileInfo.file_name));
 #endif
             if (!String(fileInfo.file_name).endsWith(".")) {
                 filenames.push_back(fileInfo);
@@ -152,6 +149,29 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, s
         file = root.openNextFile();
     }
     root.close();
+}
+} // namespace
+#endif
+
+/**
+ * @brief Get the list of files in a directory.
+ *
+ * This function returns a list of files in a directory. The list includes the full path of each file.
+ * We can't use SPILOCK here because of recursion. Callers of this function should use SPILOCK.
+ *
+ * @param dirname The name of the directory.
+ * @param levels The number of levels of subdirectories to list.
+ * @param maxCount The maximum number of file entries to return.
+ * @param wasLimited Set to true if maxCount or levels prevented a complete recursive listing.
+ * @return A vector of file metadata containing the full path of each file in the directory.
+ */
+std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount, bool *wasLimited)
+{
+    std::vector<meshtastic_FileInfo> filenames = {};
+    if (wasLimited)
+        *wasLimited = false;
+#ifdef FSCom
+    collectFiles(dirname, levels, maxCount, filenames, wasLimited);
 #endif
     return filenames;
 }

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -179,6 +179,7 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, s
     if (wasLimited)
         *wasLimited = false;
 #ifdef FSCom
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
     size_t reservedCount = maxCount;
     while (reservedCount > 0) {
         try {
@@ -188,11 +189,17 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, s
             reservedCount /= 2;
         }
     }
+    if (reservedCount == 0) {
+        if (wasLimited)
+            *wasLimited = true;
+        return filenames;
+    }
     if (reservedCount < maxCount) {
         if (wasLimited)
             *wasLimited = true;
         maxCount = reservedCount;
     }
+#endif
     collectFiles(dirname, levels, maxCount, filenames, wasLimited);
 #endif
     return filenames;

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -99,11 +99,19 @@ bool renameFile(const char *pathFrom, const char *pathTo)
 #endif
 }
 
+#include <cstring>
+#include <new>
 #include <vector>
 
 #ifdef FSCom
 namespace
 {
+bool pathEndsWithDot(const char *path)
+{
+    size_t length = strlen(path);
+    return length > 0 && path[length - 1] == '.';
+}
+
 void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vector<meshtastic_FileInfo> &filenames,
                   bool *wasLimited)
 {
@@ -123,7 +131,7 @@ void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vec
             file.close();
             break;
         }
-        if (file.isDirectory() && !String(file.name()).endsWith(".")) {
+        if (file.isDirectory() && !pathEndsWithDot(file.name())) {
             if (levels) {
 #ifdef ARCH_ESP32
                 collectFiles(file.path(), levels - 1, maxCount, filenames, wasLimited);
@@ -141,7 +149,7 @@ void collectFiles(const char *dirname, uint8_t levels, size_t maxCount, std::vec
 #else
             strlcpy(fileInfo.file_name, file.name(), sizeof(fileInfo.file_name));
 #endif
-            if (!String(fileInfo.file_name).endsWith(".")) {
+            if (!pathEndsWithDot(fileInfo.file_name)) {
                 filenames.push_back(fileInfo);
             }
             file.close();
@@ -171,6 +179,20 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, s
     if (wasLimited)
         *wasLimited = false;
 #ifdef FSCom
+    size_t reservedCount = maxCount;
+    while (reservedCount > 0) {
+        try {
+            filenames.reserve(reservedCount);
+            break;
+        } catch (const std::bad_alloc &) {
+            reservedCount /= 2;
+        }
+    }
+    if (reservedCount < maxCount) {
+        if (wasLimited)
+            *wasLimited = true;
+        maxCount = reservedCount;
+    }
     collectFiles(dirname, levels, maxCount, filenames, wasLimited);
 #endif
     return filenames;

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -111,7 +111,7 @@ bool renameFile(const char *pathFrom, const char *pathTo)
  * @param levels The number of levels of subdirectories to list.
  * @return A vector of strings containing the full path of each file in the directory.
  */
-std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
+std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount)
 {
     std::vector<meshtastic_FileInfo> filenames = {};
 #ifdef FSCom
@@ -123,12 +123,16 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels)
 
     File file = root.openNextFile();
     while (file) {
+        if (filenames.size() >= maxCount) {
+            file.close();
+            break;
+        }
         if (file.isDirectory() && !String(file.name()).endsWith(".")) {
             if (levels) {
 #ifdef ARCH_ESP32
-                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.path(), levels - 1);
+                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.path(), levels - 1, maxCount - filenames.size());
 #else
-                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.name(), levels - 1);
+                std::vector<meshtastic_FileInfo> subDirFilenames = getFiles(file.name(), levels - 1, maxCount - filenames.size());
 #endif
                 filenames.insert(filenames.end(), subDirFilenames.begin(), subDirFilenames.end());
                 file.close();

--- a/src/FSCommon.h
+++ b/src/FSCommon.h
@@ -52,7 +52,7 @@ void fsInit();
 void fsListFiles();
 bool copyFile(const char *from, const char *to);
 bool renameFile(const char *pathFrom, const char *pathTo);
-std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount = 64);
+std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount = 64, bool *wasLimited = nullptr);
 void listDir(const char *dirname, uint8_t levels, bool del = false);
 void rmDir(const char *dirname);
 void setupSDCard();

--- a/src/FSCommon.h
+++ b/src/FSCommon.h
@@ -52,7 +52,7 @@ void fsInit();
 void fsListFiles();
 bool copyFile(const char *from, const char *to);
 bool renameFile(const char *pathFrom, const char *pathTo);
-std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels);
+std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels, size_t maxCount = 64);
 void listDir(const char *dirname, uint8_t levels, bool del = false);
 void rmDir(const char *dirname);
 void setupSDCard();

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -70,10 +70,14 @@ void PhoneAPI::handleStartConfig()
         state = STATE_SEND_MY_INFO;
     }
     pauseBluetoothLogging = true;
-    spiLock->lock();
-    filesManifest = getFiles("/", 10);
-    spiLock->unlock();
-    LOG_DEBUG("Got %d files in manifest", filesManifest.size());
+    // Manifest is never read on the node-info-only path (STATE_SEND_FILEMANIFEST
+    // short-circuits to sendConfigComplete), so skip the SPI lock + FS walk.
+    if (config_nonce != SPECIAL_NONCE_ONLY_NODES) {
+        spiLock->lock();
+        filesManifest = getFiles("/", 3, 64);
+        spiLock->unlock();
+        LOG_DEBUG("Got %d files in manifest", filesManifest.size());
+    }
 
     LOG_INFO("Start API client config millis=%u", millis());
     // Protect against concurrent BLE callbacks: they run in NimBLE's FreeRTOS task and also touch nodeInfoQueue.

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -36,6 +36,17 @@
 // Flag to indicate a heartbeat was received and we should send queue status
 bool heartbeatReceived = false;
 
+namespace
+{
+constexpr uint8_t kFilesManifestLevels = 10;
+constexpr size_t kFilesManifestMaxCount = 64;
+
+void releaseFilesManifest(std::vector<meshtastic_FileInfo> &filesManifest)
+{
+    std::vector<meshtastic_FileInfo>().swap(filesManifest);
+}
+} // namespace
+
 PhoneAPI::PhoneAPI()
 {
     lastContactMsec = millis();
@@ -73,10 +84,19 @@ void PhoneAPI::handleStartConfig()
     // Manifest is never read on the node-info-only path (STATE_SEND_FILEMANIFEST
     // short-circuits to sendConfigComplete), so skip the SPI lock + FS walk.
     if (config_nonce != SPECIAL_NONCE_ONLY_NODES) {
-        spiLock->lock();
-        filesManifest = getFiles("/", 3, 64);
-        spiLock->unlock();
-        LOG_DEBUG("Got %d files in manifest", filesManifest.size());
+        bool filesManifestLimited = false;
+        {
+            concurrency::LockGuard guard(spiLock);
+            filesManifest = getFiles("/", kFilesManifestLevels, kFilesManifestMaxCount, &filesManifestLimited);
+        }
+        if (filesManifestLimited) {
+            LOG_WARN("Got %zu files in manifest (limited to %zu entries/depth %u)", filesManifest.size(), kFilesManifestMaxCount,
+                     static_cast<unsigned>(kFilesManifestLevels));
+        } else {
+            LOG_DEBUG("Got %zu files in manifest", filesManifest.size());
+        }
+    } else {
+        releaseFilesManifest(filesManifest);
     }
 
     LOG_INFO("Start API client config millis=%u", millis());
@@ -126,8 +146,7 @@ void PhoneAPI::close()
             nodeInfoQueue.clear();
         }
         packetForPhone = NULL;
-        filesManifest.clear();
-        filesManifest.shrink_to_fit();
+        releaseFilesManifest(filesManifest);
         lastPortNumToRadio.clear();
         fromRadioNum = 0;
         config_nonce = 0;
@@ -536,7 +555,7 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
         if (config_state == filesManifest.size() ||
             config_nonce == SPECIAL_NONCE_ONLY_NODES) { // also handles an empty filesManifest
             config_state = 0;
-            filesManifest.clear();
+            releaseFilesManifest(filesManifest);
             // Skip to complete packet
             sendConfigComplete();
         } else {

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -38,7 +38,7 @@ bool heartbeatReceived = false;
 
 namespace
 {
-constexpr uint8_t kFilesManifestLevels = 10;
+constexpr uint8_t kFilesManifestLevels = 3;
 constexpr size_t kFilesManifestMaxCount = 64;
 
 void releaseFilesManifest(std::vector<meshtastic_FileInfo> &filesManifest)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change prevents PhoneAPI crashes related to memory pressure during filesystem manifest generation. It does so by making filesystem enumeration bounded and more controllable, and by skipping filesystem manifest loading entirely for node-info-only (special nonce–only) configuration starts.

## Key Changes

**Fixes**
- Bound recursive directory enumeration in `FSCommon.cpp` by adding a quota (`maxCount`) to stop once enough `meshtastic_FileInfo` entries are collected.
- Report whether enumeration was truncated via a new `wasLimited` out-parameter.
- Reduce allocation risk during traversal by reserving vector capacity up to `maxCount`, with a fallback if `std::bad_alloc` occurs.
- Filter out “dot-suffixed” entries using a dedicated helper (`pathEndsWithDot`) rather than allocating/allocating temporary `String` objects per check.
- Skip filesystem manifest loading on the `SPECIAL_NONCE_ONLY_NODES` path, avoiding the SPI lock and filesystem walk.
- When manifest generation is enabled, use explicit manifest scan limits (`levels = 3`, `maxCount = 64`) and log whether the manifest was limited.

**Refactors**
- Introduced a `collectFiles` helper to implement the bounded recursive traversal and propagate remaining quota into recursive calls.
- Extended the `getFiles()` API in `FSCommon.h/.cpp` to accept `maxCount` and `wasLimited` (defaulting to `maxCount = 64` and `wasLimited = nullptr`).
- Centralized manifest cleanup into a `releaseFilesManifest()` helper and used it on early-exit paths, on close, and when finishing file manifest handling.

## Breaking Changes / Migration

- `getFiles()` now limits results by default to at most **64 entries**. Existing callers will still compile due to default arguments, but they may now receive a truncated listing.
- Callers that require more complete listings should pass a larger `maxCount`, and can use `wasLimited` to detect truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->