### PR TITLE
Add NRF52 BLE callback restoration and pairing log cleanup

### DIFF
--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -20,7 +20,7 @@ static BLEBas blebas; // BAS (Battery Service) helper class instance
 #ifndef BLE_DFU_SECURE
 static BLEDfu bledfu; // DFU software update helper service
 #else
-static BLEDfuSecure bledfusecure;                                             // DFU software update helper service
+static BLEDfuSecure bledfusecure; // DFU software update helper service
 #endif
 
 // This scratch buffer is used for various bluetooth reads/writes - but it is safe because only one bt operation can be in
@@ -258,6 +258,35 @@ int NRF52Bluetooth::getRssi()
 #define VALID_BLE_TX_POWER(x)                                                                                                    \
     ((x) == -20 || (x) == -16 || (x) == -12 || (x) == -8 || (x) == -4 || (x) == 0 || (x) == 4 || (x) == 8)
 
+void NRF52Bluetooth::restoreTxPower()
+{
+#if defined(NRF52_BLE_TX_POWER) && VALID_BLE_TX_POWER(NRF52_BLE_TX_POWER)
+    Bluefruit.setTxPower(NRF52_BLE_TX_POWER);
+#else
+    // Bluefruit.begin() default.
+    Bluefruit.setTxPower(0);
+#endif
+}
+
+void NRF52Bluetooth::restoreSecurityState()
+{
+    if (config.bluetooth.mode == meshtastic_Config_BluetoothConfig_PairingMode_NO_PIN) {
+        Bluefruit.Security.setPairPasskeyCallback(nullptr);
+        Bluefruit.Security.setPairCompleteCallback(nullptr);
+        Bluefruit.Security.setSecuredCallback(nullptr);
+        Bluefruit.Security.setIOCaps(false, false, false);
+        // setPairPasskeyCallback() enables MITM even when clearing the callback.
+        Bluefruit.Security.setMITM(false);
+        return;
+    }
+
+    Bluefruit.Security.setIOCaps(true, false, false);
+    Bluefruit.Security.setMITM(true);
+    Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onPairingPasskey);
+    Bluefruit.Security.setPairCompleteCallback(NRF52Bluetooth::onPairingCompleted);
+    Bluefruit.Security.setSecuredCallback(NRF52Bluetooth::onConnectionSecured);
+}
+
 void NRF52Bluetooth::setup()
 {
     // Initialise the Bluefruit module
@@ -269,9 +298,7 @@ void NRF52Bluetooth::setup()
     Bluefruit.Advertising.stop();
     Bluefruit.Advertising.clearData();
     Bluefruit.ScanResponse.clearData();
-#if defined(NRF52_BLE_TX_POWER) && VALID_BLE_TX_POWER(NRF52_BLE_TX_POWER)
-    Bluefruit.setTxPower(NRF52_BLE_TX_POWER);
-#endif
+    restoreTxPower();
     if (config.bluetooth.mode != meshtastic_Config_BluetoothConfig_PairingMode_NO_PIN) {
         if (config.bluetooth.mode == meshtastic_Config_BluetoothConfig_PairingMode_FIXED_PIN) {
             configuredPasskey = config.bluetooth.fixed_pin;
@@ -283,13 +310,10 @@ void NRF52Bluetooth::setup()
         auto pinString = std::to_string(configuredPasskey);
         LOG_INFO("Bluetooth pin set to '%i'", configuredPasskey);
         Bluefruit.Security.setPIN(pinString.c_str());
-        Bluefruit.Security.setIOCaps(true, false, false);
-        Bluefruit.Security.setPairPasskeyCallback(NRF52Bluetooth::onPairingPasskey);
-        Bluefruit.Security.setPairCompleteCallback(NRF52Bluetooth::onPairingCompleted);
-        Bluefruit.Security.setSecuredCallback(NRF52Bluetooth::onConnectionSecured);
+        restoreSecurityState();
         meshBleService.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
     } else {
-        Bluefruit.Security.setIOCaps(false, false, false);
+        restoreSecurityState();
         meshBleService.setPermission(SECMODE_OPEN, SECMODE_OPEN);
     }
     // Set the advertised device name (keep it short!)
@@ -347,6 +371,10 @@ void NRF52Bluetooth::setup()
 }
 void NRF52Bluetooth::resumeAdvertising()
 {
+    LOG_DEBUG("Resume NRF52 BLE advertising");
+    // shutdown() swaps security callbacks, so restore BLE state before advertising.
+    restoreSecurityState();
+    restoreTxPower();
     Bluefruit.Advertising.restartOnDisconnect(true);
     Bluefruit.Advertising.setInterval(32, 668); // in unit of 0.625 ms
     Bluefruit.Advertising.setFastTimeout(30);   // number of seconds in fast mode
@@ -434,6 +462,7 @@ bool NRF52Bluetooth::onPairingPasskey(uint16_t conn_handle, uint8_t const passke
 // On NRF52Bluetooth::shutdown, we change the pairing callback to this method, to aggressively refuse any connection attempts.
 bool NRF52Bluetooth::onUnwantedPairing(uint16_t conn_handle, uint8_t const passkey[6], bool match_request)
 {
+    LOG_WARN("Rejecting BLE pairing (onUnwantedPairing) - should only fire while Bluetooth is disabled");
     NRF52Bluetooth::disconnect();
     return false;
 }

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -308,7 +308,7 @@ void NRF52Bluetooth::setup()
             configuredPasskey = hwrand % 900000u + 100000u;
         }
         auto pinString = std::to_string(configuredPasskey);
-        LOG_INFO("Bluetooth pin set to '%i'", configuredPasskey);
+        LOG_DEBUG("Bluetooth pin configured");
         Bluefruit.Security.setPIN(pinString.c_str());
         restoreSecurityState();
         meshBleService.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
@@ -399,9 +399,7 @@ void NRF52Bluetooth::onConnectionSecured(uint16_t conn_handle)
 }
 bool NRF52Bluetooth::onPairingPasskey(uint16_t conn_handle, uint8_t const passkey[6], bool match_request)
 {
-    char passkey1[4] = {passkey[0], passkey[1], passkey[2], '\0'};
-    char passkey2[4] = {passkey[3], passkey[4], passkey[5], '\0'};
-    LOG_INFO("BLE pair process started with passkey %s %s", passkey1, passkey2);
+    LOG_INFO("BLE pair process started: match_request=%i", match_request);
     powerFSM.trigger(EVENT_BLUETOOTH_PAIR);
 
     // Get passkey as string
@@ -447,7 +445,6 @@ bool NRF52Bluetooth::onPairingPasskey(uint16_t conn_handle, uint8_t const passke
     passkeyShowing = true;
 
     // Pairing completion or disconnect dismisses the passkey UI; blocking here stalls BLE event processing.
-    LOG_INFO("BLE passkey pair: match_request=%i", match_request);
     return true;
 }
 

--- a/src/platform/nrf52/NRF52Bluetooth.cpp
+++ b/src/platform/nrf52/NRF52Bluetooth.cpp
@@ -446,13 +446,7 @@ bool NRF52Bluetooth::onPairingPasskey(uint16_t conn_handle, uint8_t const passke
 #endif
     passkeyShowing = true;
 
-    if (match_request) {
-        uint32_t start_time = millis();
-        while (millis() < start_time + 30000) {
-            if (!Bluefruit.connected(conn_handle))
-                break;
-        }
-    }
+    // Pairing completion or disconnect dismisses the passkey UI; blocking here stalls BLE event processing.
     LOG_INFO("BLE passkey pair: match_request=%i", match_request);
     return true;
 }

--- a/src/platform/nrf52/NRF52Bluetooth.h
+++ b/src/platform/nrf52/NRF52Bluetooth.h
@@ -19,6 +19,8 @@ class NRF52Bluetooth : BluetoothApi
     static void onConnectionSecured(uint16_t conn_handle);
     static bool onPairingPasskey(uint16_t conn_handle, uint8_t const passkey[6], bool match_request);
     static void onPairingCompleted(uint16_t conn_handle, uint8_t auth_status);
+    static void restoreSecurityState();
+    static void restoreTxPower();
 
     static bool onUnwantedPairing(uint16_t conn_handle, uint8_t const passkey[6], bool match_request);
     static void disconnect();


### PR DESCRIPTION


## Summary by Sourcery

Restore NRF52 BLE security callbacks and TX power configuration when starting or resuming advertising, and simplify pairing logging and behavior.

Bug Fixes:
- Ensure BLE security callbacks and IO capabilities are correctly restored after shutdown before advertising resumes, preventing unwanted pairing behavior.
- Reset TX power to the configured or default value whenever BLE is set up or advertising is resumed to avoid incorrect radio power states.
- Avoid blocking BLE event processing during pairing by removing the busy-wait loop on match requests.

Enhancements:
- Centralize restoration of BLE security state and TX power into dedicated helper methods for reuse in setup and advertising flows.
- Reduce and clarify Bluetooth pairing logs, including a clearer log for rejected unwanted pairing attempts and less verbose PIN logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth startup and resume so transmit power and security/pairing settings are consistently restored.
  * Updated advertising resume to reapply the correct security state and power settings before advertising restarts.
  * Streamlined the BLE pairing passkey flow to avoid delays from a blocking wait.
  * Refreshed pairing-related logs and warnings to clarify when pairing rejection is expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->